### PR TITLE
Add prereqs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ By answering a few simple questions, an entire skeleton build will be generated 
 This project requires the latest version (1.8.5) of the Yeoman CLI library, [`yo`](https://www.npmjs.com/package/yo).
 
 ```bash
+# verify current version
+$ yo --version
+
+# if necessary, install or update yo
 $ npm install -g yo
 
 # or to update

--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ By answering a few simple questions, an entire skeleton build will be generated 
 [Gulp]: http://gulpjs.com/
 [Keystone]: https://github.com/kenzanlabs/keystone
 
+## Prerequisite 
+
+This project requires the latest version (1.8.5) of the Yeoman CLI library, [`yo`](https://www.npmjs.com/package/yo).
+
+```bash
+$ npm install -g yo
+
+# or to update
+$ npm update -g yo
+```
+
 ## Install
 As this project is still in development and not published in NPM, please install via our Github repo
 


### PR DESCRIPTION
**Associated Issue**
#20 

**Changes Made**
- A possible cause to the error was an outdating `yo` global package. A "Prerequisite" section was added to the README to ensure the latest `yo` package is installed.